### PR TITLE
Update POS dashboard data loading effect

### DIFF
--- a/src/components/pos/POSDashboard.tsx
+++ b/src/components/pos/POSDashboard.tsx
@@ -329,13 +329,18 @@ export const POSDashboard: React.FC = () => {
 
   // Load orders, tables and subscribe when tenantId is available - prevent duplicate calls
   useEffect(() => {
-    if (tenantId && !ordersLoading && !tablesLoading) {
-      loadOrders();
-      loadTables();
-      const unsubscribe = subscribeToOrders();
-      return unsubscribe;
+    if (!tenantId) {
+      return;
     }
-  }, [tenantId]); // Remove callback dependencies to prevent infinite loops
+
+    loadOrders();
+    loadTables();
+    const unsubscribe = subscribeToOrders();
+
+    return () => {
+      unsubscribe?.();
+    };
+  }, [tenantId, loadOrders, loadTables, subscribeToOrders]);
 
   const updateOrderStatus = async (orderId: string, newStatus: POSOrder['status']) => {
     try {


### PR DESCRIPTION
## Summary
- ensure POS dashboard data loading and subscription effect runs when a tenant becomes available
- simplify initial load guard so orders and tables fetch on first render

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d945d860d88332be42579583cb8983