### PR TITLE
Fix POS timeout handling when auth data loads

### DIFF
--- a/src/pages/POSSystem.tsx
+++ b/src/pages/POSSystem.tsx
@@ -79,6 +79,10 @@ const POSSystem = (): JSX.Element => {
     }
   }, [loading, user, tenantId, isAdmin, checkingSubscription, tenant]);
 
+  const isStillLoadingAuth = loading && !user;
+  const isStillLoadingSubscription = checkingSubscription && !tenant && !user;
+  const shouldShowTimeout = loadingTimeout && (isStillLoadingAuth || isStillLoadingSubscription);
+
   // Only show loading if we're actually loading and haven't timed out
   if ((loading || checkingSubscription) && !loadingTimeout) {
     return (
@@ -92,12 +96,7 @@ const POSSystem = (): JSX.Element => {
     );
   }
 
-  // Force show content if timeout reached, even if still loading
-  if (loadingTimeout && user) {
-    // Skip further loading checks and show dashboard
-  }
-
-  if (loadingTimeout) {
+  if (shouldShowTimeout) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-background to-secondary/20 flex items-center justify-center">
         <div className="text-center max-w-md mx-auto p-6">


### PR DESCRIPTION
## Summary
- add derived timeout guards that require both an elapsed timer and missing auth/subscription data
- ensure the POS dashboard renders once a user record arrives even after the timeout triggers

## Testing
- `npx playwright test tests/pos-access-redirect.spec.ts` *(fails: Playwright browsers unavailable in environment)*
- `npx playwright install chromium` *(fails: browser download blocked by environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d94644789c83328cc32a80bcb35a77